### PR TITLE
17052020 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ PLUGINS_CONFIG = {
 | device_img      | 'access-switch,core-switch,firewall,router,distribution-switch,backup,storage,wan-network,wireless-ap,server,internal-switch,isp-cpe-material,non-racked-devices,power-units' | The slug of the device roles that you have a image for. |
 | preselected_device_roles      | 'Firewall,Router,Distribution Switch,Core Switch,Internal Switch,Access Switch,Server,Storage,Backup,Wireless AP' | The full name of the device roles you want to pre select in the global view.  Note that this is case sensitive|
 | allow_coordinates_saving      | False | (bool) Set to true if you use the custom coordinates fields and want to save the coordinates |
-| ignore_cable_type      | 'poweroutlet,powerport' | The cable types that you want to ignore in the views  |
+| ignore_cable_type      | 'power outlet,power port' | The cable types that you want to ignore in the views  |
 | preselected_tags      | '' | The name of tags you want to preload  |
 
 

--- a/netbox_topology_views/__init__.py
+++ b/netbox_topology_views/__init__.py
@@ -11,7 +11,7 @@ class TopologyViewsConfig(PluginConfig):
     required_settings = []
     default_settings = {
         'preselected_device_roles': 'Firewall,Router,Distribution Switch,Core Switch,Internal Switch,Access Switch,Server,Storage,Backup,Wireless AP',
-        'ignore_cable_type': 'poweroutlet,powerport',
+        'ignore_cable_type': 'power outlet,power port',
         'device_img': 'access-switch,core-switch,firewall,router,distribution-switch,backup,storage,wan-network,wireless-ap,server,internal-switch,isp-cpe-material,non-racked-devices,power-units',
         'allow_coordinates_saving': False,
         'preselected_tags' : ''

--- a/netbox_topology_views/__init__.py
+++ b/netbox_topology_views/__init__.py
@@ -4,7 +4,7 @@ class TopologyViewsConfig(PluginConfig):
     name = 'netbox_topology_views'
     verbose_name = 'Topology views'
     description = 'An plugin to render toplogoy maps'
-    version = '0.4.0'
+    version = '0.4.1'
     author = 'Mattijs Vanhaverbeke'
     author_email = 'author@example.com'
     base_url = 'topology-views'

--- a/netbox_topology_views/api/views.py
+++ b/netbox_topology_views/api/views.py
@@ -123,16 +123,20 @@ class SearchViewSet(GenericViewSet):
         for device in devices:
             cables = device.get_cables()
             for cable in cables:
-                if cable.id not in cable_ids:
-                    if cable.termination_a_type.name not in ignore_cable_type:
-                        cable_ids.append(cable.id)
-                        edge_ids += 1
-                        edge = {}
-                        edge["id"] = edge_ids
-                        edge["from"] = cable.termination_a.device.id
-                        edge["to"] = cable.termination_b.device.id
-                        edge["title"] = "Connection between <br> " + cable.termination_a.device.name + " [" + cable.termination_a.name +  "]<br>" + cable.termination_b.device.name + " [" + cable.termination_b.name + "]"
-                        edges.append(edge)
+                if cable.termination_a_type.name != "circuit termination" and cable.termination_b_type.name != "circuit termination":
+                    if cable.id not in cable_ids:
+                        if cable.termination_a_type.name not in ignore_cable_type and cable.termination_b_type.name not in ignore_cable_type:
+                            cable_ids.append(cable.id)
+                            edge_ids += 1
+                            edge = {}
+                            edge["id"] = edge_ids
+                            edge["from"] = cable.termination_a.device.id
+                            edge["to"] = cable.termination_b.device.id
+                            edge["title"] = "Connection between <br> " + cable.termination_a.device.name + " [" + cable.termination_a.name +  "]<br>" + cable.termination_b.device.name + " [" + cable.termination_b.name + "]"
+                            edges.append(edge)
+                else:
+                    pass
+                    #circuittermination not supported for now
             node = {}
             node["id"] = device.id
             node["name"] = device.name

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "netbox_topology_views",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "resources": "gulp build",
     "resources_dev": "gulp build_dev"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='netbox-topology-views',
-    version='0.4.0',
+    version='0.4.1',
     description='An NetBox plugin to create Topology maps',
     url='https://github.com/mattieserver/netbox-topology-views',
     author='Mattijs Vanhaverbeke',


### PR DESCRIPTION
#10 
"circuit termination" cable type excluded for now.
Because the cable does not always terminate on a device.
