### PR TITLE
color the edges

### DIFF
--- a/netbox_topology_views/api/views.py
+++ b/netbox_topology_views/api/views.py
@@ -147,6 +147,8 @@ class SearchViewSet(GenericViewSet):
                             edge["from"] = cable.termination_a.device.id
                             edge["to"] = cable.termination_b.device.id
                             edge["title"] = "Connection between <br> " + cable_a_dev_name + " [" + cable_a_name +  "]<br>" + cable_b_dev_name + " [" + cable_b_name + "]"
+                            if cable.color != "":
+                                edge["color"] = "#" + cable.color
                             edges.append(edge)
                 else:
                     pass


### PR DESCRIPTION
When a cable has a color set, use this color for the edge which
repesents the cable, so that a cabling type or maybe a purpose of the cable
could be seen in the topology graph.