### PR TITLE
Netbox 2.10.0+ Compatibility

### DIFF
--- a/netbox_topology_views/api/views.py
+++ b/netbox_topology_views/api/views.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from .serializers import PreDeviceRoleSerializer, TopologyDummySerializer, PreTagSerializer
 from django.conf import settings
 
-from utilities.api import IsAuthenticatedOrLoginNotRequired
+from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 
 from dcim.models import  DeviceRole, Device, Cable
 from circuits.models import Circuit


### PR DESCRIPTION
`IsAuthenticatedOrLoginNotRequired` now comes from `netbox.api.authentication`, instead of `utilities.api` as of netbox v. 2.10.0