### PR TITLE
 disable physics if not saving coords

### DIFF
--- a/netbox_topology_views/__init__.py
+++ b/netbox_topology_views/__init__.py
@@ -4,7 +4,7 @@ class TopologyViewsConfig(PluginConfig):
     name = 'netbox_topology_views'
     verbose_name = 'Topology views'
     description = 'An plugin to render topology maps'
-    version = '2.0.2'
+    version = '2.0.4'
     author = 'Mattijs Vanhaverbeke'
     author_email = 'author@example.com'
     base_url = 'netbox_topology_views'

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -1,5 +1,3 @@
-import ipaddress
-import slugify
 from django.shortcuts import get_object_or_404, render
 from django.db.models import Q
 from django.views.generic import View
@@ -61,18 +59,20 @@ def create_node(device, save_coords):
     if device.device_role.color != "":
         node["color.border"] = "#" + device.device_role.color
 
-    if save_coords:
-        # Load coordinates and disable physics
-        node["physics"] = False
-        if "coordinates" in device.custom_field_data:
-            if device.custom_field_data["coordinates"] is not None:
-                if ";" in device.custom_field_data["coordinates"]:
-                    cords =  device.custom_field_data["coordinates"].split(";")
-                    node["x"] = int(cords[0])
-                    node["y"] = int(cords[1])
-    else:
-        # Enable physics without loading coordinates
-        node["physics"] = True
+    node["physics"] = True
+
+    if "coordinates" in device.custom_field_data:
+        if device.custom_field_data["coordinates"] is not None:
+            if ";" in device.custom_field_data["coordinates"]:
+                cords =  device.custom_field_data["coordinates"].split(";")
+                node["x"] = int(cords[0])
+                node["y"] = int(cords[1])
+                node["physics"] = False
+        else:
+            if save_coords:
+                node["physics"] = False
+            else:
+                node["physics"] = True
     return node
 
 def create_edge(edge_id, cable, termination_a, termination_b, path = None, circuit = None):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(top_level_directory, 'README.md'), encoding='utf-8') as file
 
 setup(
     name='netbox-topology-views',
-    version='2.0.3',
+    version='2.0.4',
     description='An NetBox plugin to create Topology maps',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
(making a new PR)
I had issues in the following two scenarios:

 * not saving coordinates, but coordinates are previously saved: current behavior physics=True, expected physics=False
 * saving coordinates but nodes doesn't have a saved one: current behavior physics=True, expected physics=False

@mattieserver  me know if that make sense for you.
