### PR TITLE
Add wireless link support

### DIFF
--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -99,8 +99,11 @@ def create_edge(edge_id, cable, termination_a, termination_b, path = None, circu
     if path is not None:
         edge["title"] += "" if len(path) <= 0 else "<br>Through " + "/".join(path)
         
-    if cable is not None and cable.color != "":
-        edge["color"] = "#" + cable.color
+    if isinstance(cable, WirelessLink):
+        edge['dashes'] = True
+    else:
+        if cable is not None and cable.color != "":
+            edge["color"] = "#" + cable.color
 
     return edge
 

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -101,6 +101,11 @@ def create_edge(edge_id, cable, termination_a, termination_b, path = None, circu
         
     if isinstance(cable, WirelessLink):
         edge['dashes'] = True
+        edge['title'] = f"""
+            Wireless link between<br>
+            {cable_a_dev_name} [{cable_a_name}]<br>
+            {cable_b_dev_name} [{cable_b_name}]
+        """
     else:
         if cable is not None and cable.color != "":
             edge["color"] = "#" + cable.color

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -269,7 +269,7 @@ def get_topology_data(queryset, hide_unconnected, save_coords, intermediate_dev_
                 create_edge(
                     # Flag the wireless ID with a 'w' to avoid conflicts
                     f"w{wireless_link.id}",
-                    None, # Cable (only used for the cable color)
+                    wireless_link, # Cable (only used for the cable color)
                     wireless_link.interface_a,
                     wireless_link.interface_b,
                     None, # path (should not be applicable here?)

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -14,8 +14,7 @@ import json
 from dcim.models import Device, Cable, DeviceRole, PathEndpoint
 from circuits.models import CircuitTermination, ProviderNetwork
 from extras.models import Tag
-if 'wireless' in settings.INSTALLED_APPS:
-    from wireless.models import WirelessLink
+from wireless.models import WirelessLink
 
 
 def create_node(device, save_coords):
@@ -102,7 +101,7 @@ def create_edge(edge_id, cable, termination_a, termination_b, path = None, circu
         
     if cable is not None and cable.color != "":
         edge["color"] = "#" + cable.color
-    
+
     return edge
 
 def get_topology_data(queryset, hide_unconnected, save_coords, intermediate_dev_role_ids, end2end_connections):
@@ -257,7 +256,7 @@ def get_topology_data(queryset, hide_unconnected, save_coords, intermediate_dev_
     # endfor (link)
 
     # Add wireless links as edges
-    if 'wireless' in settings.INSTALLED_APPS and 'wireless-link' not in ignore_cable_type:
+    if 'wireless-link' not in ignore_cable_type:
         wireless_links = WirelessLink.objects.filter(
             Q(_interface_a_device_id__in=device_ids) | Q(_interface_b_device_id__in=device_ids)
         ).prefetch_related("interface_a", "interface_b")


### PR DESCRIPTION
This adds wireless links (not wireless LANs). Looking at the readme this plugin >= v1.1.0 requires netbox >= 3.2.0 anyway so I removed the version checks.

Still to do:
- The wireless link is dashed but wireless links don't have a color on the model, should I assign a particular color (or maybe reduce the opacity) to better indicate its a wireless link?
- Frequencies are on the interfaces, should these be brought in and displayed in the tool tip?

Anything else that you guys might want added.

To try it out instead of `netbox-topology-views` in the requirements.txt use `git+https://github.com/dmcken/netbox-topology-views.git@add-wireless-link-support#egg=netbox-topology-views`