### PR TITLE
Closes #210: Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,52 @@
+---
+name: 🐛 Bug Report
+description: Report a reproducible bug in the current release of NetBox
+labels: ["type: bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **NOTE:** This form is only for reporting _reproducible bugs_. If you're having 
+        trouble with installation or just looking for assistance with using NetBox 
+        Topology Views, please visit our 
+        [discussion forum](https://github.com/mattieserver/netbox-topology-views/discussions) instead.
+  - type: input
+    attributes:
+      label: NetBox version
+      description: What version of NetBox are you currently running?
+      placeholder: v3.3.9
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Topology Views version
+      description: What version of NetBox Topology Views are you currently running?
+      placeholder: v3.1.0
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: >
+        Describe in detail the exact steps that someone else can take to
+        reproduce this bug using the current stable release of NetBox Topology Views.
+      placeholder: |
+        1. Click on "create widget"
+        2. Set foo to 12 and bar to G
+        3. Click the "create" button
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: A new widget should have been created with the specified attributes
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Observed Behavior
+      description: What happened instead?
+      placeholder: A TypeError exception was raised
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Discussion
+    url: https://github.com/mattieserver/netbox-topology-views/discussions
+    about: "If you're just looking for help, try starting a discussion instead"

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,58 @@
+---
+name: ✨ Feature Request
+description: Propose a new NetBox Topology Views feature or enhancement
+labels: ["type: feature"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **NOTE:** This form is only for submitting well-formed proposals to extend or modify
+        NetBox Topology Views in some way. If you're trying to solve a problem but can't figure 
+        out how, or if you still need time to work on the details of a proposed new feature, 
+        please start a [discussion](https://github.com/mattieserver/netbox-topology-views/discussions) instead.
+  - type: input
+    attributes:
+      label: NetBox version
+      description: What version of NetBox are you currently running?
+      placeholder: v3.3.9
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Topology Views version
+      description: What version of NetBox Topology Views are you currently running?
+      placeholder: v3.1.0
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Feature type
+      options:
+        - New functionality
+        - Change to existing functionality
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed functionality
+      description: >
+        Describe in detail the new feature or behavior you are proposing. Include any specific changes
+        to work flows and/or the user interface. The more detail you provide here, the
+        greater chance your proposal has of being discussed. Feature requests which don't include an
+        actionable implementation plan will be rejected.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Use case
+      description: >
+        Explain how adding this functionality would benefit NetBox Topology Views users. What need does it address?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: External dependencies
+      description: >
+        List any new dependencies on external libraries or services that this new feature would
+        introduce. For example, does the proposal require the installation of a new Python package?
+        (Not all new features introduce new dependencies.)


### PR DESCRIPTION
Issue templates basically borrowed and customized from the NetBox repository. Statuses in the templates match the ones I just created.

I wasn't able to test this in my fork, so be please check functionality after merging.