### PR TITLE
Closes #254: Add a url to cable trace for logical connections

### DIFF
--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -225,7 +225,7 @@ def create_edge(
         edge["dashes"] = [1, 10, 1, 10]
         edge["arrows"] = {"to": {"enabled": True, "scaleFactor": 0.5}, "from": {"enabled": True, "scaleFactor": 0.5}}
         edge["color"] = '#f1c232'
-        edge["href"] = interface.get_absolute_url() + "/trace"
+        edge["href"] = interface.get_absolute_url() + "trace"
         
     edge[
         "title"

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -178,7 +178,7 @@ def create_edge(
     cable: Optional[Cable] = None,
     wireless: Optional[Dict] = None,
     power: Optional[bool] = None,
-    interface: Optional[bool] = None,
+    interface: Optional[Interface] = None,
 ):
     cable_a_name = (
         "device A name unknown"
@@ -225,6 +225,7 @@ def create_edge(
         edge["dashes"] = [1, 10, 1, 10]
         edge["arrows"] = {"to": {"enabled": True, "scaleFactor": 0.5}, "from": {"enabled": True, "scaleFactor": 0.5}}
         edge["color"] = '#f1c232'
+        edge["href"] = interface.get_absolute_url() + "/trace"
         
     edge[
         "title"
@@ -445,7 +446,7 @@ def get_topology_data(
                     edge_ids += 1
                     termination_a = { "termination_name": interface.name, "termination_device_name": interface.device.name, "device_id": interface.device.id }
                     termination_b = { "termination_name": destination.name, "termination_device_name": destination.device.name, "device_id": destination.device.id }
-                    edges.append(create_edge(edge_id=edge_ids, termination_a=termination_a, termination_b=termination_b, interface=True))
+                    edges.append(create_edge(edge_id=edge_ids, termination_a=termination_a, termination_b=termination_b, interface=interface))
                     nodes_devices[interface.device.id] = interface.device
                     nodes_devices[destination.device.id] = destination.device
 


### PR DESCRIPTION
This makes it quick and easy to navigate to the complete cable trace for a logical connection. Double clicking on a logical connection will open the cable trace for the involved interface.

Closes #254 

<!--
    IMPORTANT:
    ==========
    Thank you for contributing to NetBox Topology Views! Please 
    note that our contribution guidelines require a feature 
    request or bug report to be labeled "status: accepted". This 
    helps avoid waste time and effort on a proposed change that 
    we might not be able to accept.

    Please prefix the title of your pull request according to 
    it's type. You should use "Closes #FEATURE_ID: ..." for feature 
    requests and "Fixes #ISSUE_ID: ..." for issues. This helps 
    us closing issues automatically after merging.

    To sum it up:
    1. Create Bug Report or Feature Request
    2. Wait until the issue has been labeled "status: accepted"
    3. Start working on the issue in a seperate branch
    3. Create a pull request and name the title with a prefix 
       according to the issue ID.
-->
