### PR TITLE
Fixes #274: Incorrect names displayed for power panels/feeds

### DIFF
--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -64,7 +64,7 @@ def create_node(
     node = {}
     node_content = ""
     if isinstance(device, Circuit):
-        dev_name = f"Circuit {device.cid}"
+        dev_name = device.cid
         node["id"] = f"c{device.pk}"
 
         if device.provider is not None:
@@ -74,7 +74,7 @@ def create_node(
         if device.type is not None:
             node_content += f"<tr><th>Type: </th><td>{device.type.name}</td></tr>"
     elif isinstance(device, PowerPanel):
-        dev_name = f"Power Panel {device.pk}"
+        dev_name = device.name
         node["id"] = f"p{device.pk}"
 
         if device.site is not None:
@@ -84,7 +84,7 @@ def create_node(
                 f"<tr><th>Location: </th><td>{device.location.name}</td></tr>"
             )
     elif isinstance(device, PowerFeed):
-        dev_name = f"Power Feed {device.pk}"
+        dev_name = device.name
         node["id"] = f"f{device.pk}"
 
         if device.power_panel is not None:
@@ -104,7 +104,7 @@ def create_node(
     else:
         dev_name = device.name
         if dev_name is None:
-            dev_name = "device name unknown"
+            dev_name = device.device_type.get_full_name
 
         if device.device_type is not None:
             node_content += (


### PR DESCRIPTION
Just a few very small changes:

- Changed formatted strings like f"Power Feed {device.id}" into device.name respectively f"Circuit {device.cid}" were change to device.cid. I removed the prefixes because I didn't get the point in prefixing the names with "Circuit", "Power Panel" and "Power Feed". The name should clearly show you what kind of device is behind it (if the name is not a completely goofy choice). Otherwise, it would be consequential to implement this for all other species as well.
After doing some tests I decided to not checking for None type and if the "name" variable exists. Since "name" in the form is a mandatory field it is not possible to set an empty string or omit the name. It is not even possible to set the database field NULL, because it's a not nullable field. Even if this might have been different in the past, the database would have to have converted the non-compliant fields.
- I have changed the verification of None type for normal devices. Instead of the not very specific "device name unknown" string, the Device Type (and Manufacturer) is displayed, just like when you open the device details.