### PR TITLE
Fixes #340: Version 3.6 does not work with netbox 3.4.x because of migration dependencies

### DIFF
--- a/netbox_topology_views/migrations/0004_coordinategroup_coordinate.py
+++ b/netbox_topology_views/migrations/0004_coordinategroup_coordinate.py
@@ -9,8 +9,6 @@ import utilities.json
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dcim', '0171_cabletermination_change_logging'),
-        ('extras', '0092_delete_jobresult'),
         ('netbox_topology_views', '0003_individualoptions_show_neighbors'),
     ]
 


### PR DESCRIPTION
Makemigrations automatically creates dependencies on dcim and extras. This is because dcim.device is referenced in the model. These dependencies are redundant in this case, because dcim.device exists in NetBox from the very beginning. The new dependency is caused by a change that has been made to the dcim model. Same story with extras.

I deleted the dependencies from the migration script by hand in order to make this version compatible to NetBox 3.4.