### PR TITLE
Fixes #407 - Override form renderer to fix the plugin for netbox v3.6.4

### DIFF
--- a/netbox_topology_views/forms.py
+++ b/netbox_topology_views/forms.py
@@ -30,6 +30,7 @@ class DeviceFilterForm(
     ContactModelFilterForm,
     NetBoxModelFilterSetForm
 ):
+    default_renderer = forms.renderers.DjangoTemplates()
     model = Device
     fieldsets = (
         (None, ('q', 'filter_id', 'tag')),


### PR DESCRIPTION
Fixes #407

Simply override the form renderer. I had a quick look at the other forms, and I think this is only necessary for the one form.

Please give it a quick test before merging.