### PR TITLE
fix 535 saved filter params not defined

### DIFF
--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -745,7 +745,7 @@ class TopologyHomeView(PermissionRequiredMixin, View):
                     print(type(inst))
 
             if "group" not in request.GET:
-                if 'group' in saved_filter_params:
+                if 'saved_filter_params' in locals() and "group" in saved_filter_params:
                     group_id = saved_filter_params['group'][0]
                 else:
                     group_id = "default"


### PR DESCRIPTION
I overlooked to check if saved_filter_params is defined.