### PR TITLE
Fixes #464: Topology not showing properly when using other language than english

### DIFF
--- a/netbox_topology_views/api/serializers.py
+++ b/netbox_topology_views/api/serializers.py
@@ -50,4 +50,4 @@ class PowerFeedCoordinateSerializer(NetBoxModelSerializer):
 class IndividualOptionsSerializer(NetBoxModelSerializer):
     class Meta:
         model = IndividualOptions
-        fields = ("ignore_cable_type", "save_coords", "show_unconnected", "show_cables", "show_logical_connections", "show_single_cable_logical_conns", "show_neighbors", "show_circuit", "show_power", "show_wireless", "group_sites", "group_locations", "group_racks", "group", "draw_default_layout", "straight_cables")
+        fields = ("ignore_cable_type", "save_coords", "show_unconnected", "show_cables", "show_logical_connections", "show_single_cable_logical_conns", "show_neighbors", "show_circuit", "show_power", "show_wireless", "group_sites", "group_locations", "group_racks", "draw_default_layout", "straight_cables")

--- a/netbox_topology_views/models.py
+++ b/netbox_topology_views/models.py
@@ -331,12 +331,12 @@ class PowerFeedCoordinate(NetBoxModel):
 class IndividualOptions(NetBoxModel):
     CHOICES = (
         ('interface', 'interface'),
-        ('front port', 'front port'),
-        ('rear port', 'rear port'),
-        ('power outlet', 'power outlet'),
-        ('power port', 'power port'),
-        ('console port', 'console port'),
-        ('console server port', 'console server port'),
+        ('front port', 'frontport'),
+        ('rear port', 'rearport'),
+        ('power outlet', 'poweroutlet'),
+        ('power port', 'powerport'),
+        ('console port', 'consoleport'),
+        ('console server port', 'consoleserverport'),
     )
 
     user_id = models.IntegerField(

--- a/netbox_topology_views/models.py
+++ b/netbox_topology_views/models.py
@@ -331,12 +331,12 @@ class PowerFeedCoordinate(NetBoxModel):
 class IndividualOptions(NetBoxModel):
     CHOICES = (
         ('interface', 'interface'),
-        ('front port', 'frontport'),
-        ('rear port', 'rearport'),
-        ('power outlet', 'poweroutlet'),
-        ('power port', 'powerport'),
-        ('console port', 'consoleport'),
-        ('console server port', 'consoleserverport'),
+        ('frontport', 'frontport'),
+        ('rearport', 'rearport'),
+        ('poweroutlet', 'poweroutlet'),
+        ('powerport', 'powerport'),
+        ('consoleport', 'consoleport'),
+        ('consoleserverport', 'consoleserverport'),
     )
 
     user_id = models.IntegerField(

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -560,11 +560,11 @@ def get_topology_data(
         ).select_related("termination_type")
 
         for link in links:
-            if link.termination_type.name in ignore_cable_type:
+            if link.termination_type.model in ignore_cable_type:
                 continue
 
             # Normal device cables
-            if link.termination_type.name in supported_termination_types:
+            if link.termination_type.model in supported_termination_types:
                 complete_link = False
                 if link.cable_end == "A":
                     if link.cable_id not in cable_ids:


### PR DESCRIPTION
Fixes #464: Topology not showing properly when using other language than english

Changed CHOICES to model names since type names are being translated and are therefore not reliable. Comparison is being done using model names now.

If Ignore Termination Types has been set in Individual Options, it is necessary to remove and re-set them.