### PR TITLE
ENG-3602 initial plugin manifest 

### DIFF
--- a/.github/workflows/manifest-modified.yaml
+++ b/.github/workflows/manifest-modified.yaml
@@ -1,0 +1,15 @@
+name: NetBox plugin manifest modified
+
+on:
+  push:
+    branches: [ develop ]
+    paths:
+      - netbox-plugin.yaml
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  manifest-modified:
+    uses: netboxlabs/public-workflows/.github/workflows/reusable-plugin-manifest-modified.yml@release

--- a/netbox-plugin.yaml
+++ b/netbox-plugin.yaml
@@ -1,0 +1,21 @@
+version: 0.1
+package_name: netbox-topology-views
+compatibility:
+  - release: 4.1.0
+    netbox_min: 4.1.0
+    netbox_max: 4.1.3
+  - release: 4.0.0
+    netbox_min: 4.0.0
+    netbox_max: 4.0.9
+  - release: 3.9.1
+    netbox_min: 3.7.1
+    netbox_max: 3.7.8
+  - release: 3.9.0
+    netbox_min: 3.7.1
+    netbox_max: 3.7.8
+  - release: 3.8.1
+    netbox_min: 3.6.9
+    netbox_max: 3.6.9
+  - release: 3.6.2
+    netbox_min: 3.5.1
+    netbox_max: 3.5.9


### PR DESCRIPTION
- Initial `netbox-plugin.yaml` plugin manifest, to signal explicit plugin compatibility to the NetBox plugin catalog.
- Additional Github action that will trigger central workflows when the `netbox-plugin.yaml` file is modified.
