### PR TITLE
Update plugin manifest for topology views v4.0.1 and netbox v4.1.4

### DIFF
--- a/netbox-plugin.yaml
+++ b/netbox-plugin.yaml
@@ -3,7 +3,10 @@ package_name: netbox-topology-views
 compatibility:
   - release: 4.1.0
     netbox_min: 4.1.0
-    netbox_max: 4.1.3
+    netbox_max: 4.1.4
+  - release: 4.0.1
+    netbox_min: 4.0.9
+    netbox_max: 4.0.11
   - release: 4.0.0
     netbox_min: 4.0.0
     netbox_max: 4.0.9


### PR DESCRIPTION

 Bumps plugin manifest to include NetBox Topology views v4.0.1 (NetBox v4.0.9-v4.0.11); and netbox_max to v4.1.4 for Topology Views v4.1.0