### PR TITLE
Use new version identifier from Netbox

### DIFF
--- a/netbox_topology_views/template_content.py
+++ b/netbox_topology_views/template_content.py
@@ -3,7 +3,7 @@ from netbox.plugins import PluginTemplateExtension
 from django.conf import settings
 from packaging import version
 
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
+NETBOX_CURRENT_VERSION = version.parse(settings.RELEASE.version)
 
 
 class SiteButtons(PluginTemplateExtension):


### PR DESCRIPTION
Fix #604

Netbox changed the version identifier in https://github.com/netbox-community/netbox/issues/15908
