### PR TITLE
Fixes #683: Fix crash when rendering WirelessLink without label

### DIFF
--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -322,9 +322,10 @@ def create_edge(
         edge["color"] = '#f1c232'
         edge["href"] = interface.get_absolute_url() + "trace"
     
-    cable_label = ""
     if cable is not None and hasattr(cable, "label") and cable.label:
         cable_label = "<br>Label: " + cable.label
+    else:
+        cable_label = ""
 
     edge[
         "title"

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -322,10 +322,9 @@ def create_edge(
         edge["color"] = '#f1c232'
         edge["href"] = interface.get_absolute_url() + "trace"
     
-    if cable is not None and cable.label:
-        cable_label = "<br>Label: " + cable.label
-    else:
-        cable_label = ""
+    cable_label = ""
+    if cable is not None and hasattr(cable, "label") and cable.label:
+        cable_label = "<br>Label: " + str(cable.label)
 
     edge[
         "title"

--- a/netbox_topology_views/views.py
+++ b/netbox_topology_views/views.py
@@ -324,7 +324,7 @@ def create_edge(
     
     cable_label = ""
     if cable is not None and hasattr(cable, "label") and cable.label:
-        cable_label = "<br>Label: " + str(cable.label)
+        cable_label = "<br>Label: " + cable.label
 
     edge[
         "title"


### PR DESCRIPTION
### Summary
This PR fixes a crash when enabling "Show Wireless Links" in the topology view.

### Problem
When "Show Wireless Links" is enabled, NetBox Topology Views can raise:
```
AttributeError: 'WirelessLink' object has no attribute 'label'
```
This happens because `WirelessLink` objects do not have a `label` attribute,
but the topology view code assumes its existence.

### Fix
Guard access to `label` using `hasattr` and only render the label when it exists.
This avoids the AttributeError while preserving existing behavior for `Cable`.

### Tested
- NetBox v4.4.7 (Community)
- netbox-topology-views v4.4.0
- Kubernetes deployment with custom NetBox image to use the plugin

Fixes #683
